### PR TITLE
make sure formater removes trailing whitespace at end of line to comp…

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ Typing `ul` or `ol`
 
 * For `，,。;；！、？：` add a space after these symbols; 
 * `，：；！“”‘’（）？。` , unify it as a half-width character(Optional); 
-* `.!?` add a space after these symbols, if before uppercases or chineses; 
+* `.!?` add a space after these symbols, if before uppercases or chineses; Add `endOfLineSpaces` spaces if it ends a line.
 * Supports converting Chinese symbols into full-width symbols according to context, or converting English into half-width symbols; 
 * a space before and after the back-quote, which wrapped by back-quote will not be formatted; 
+
 
 #### line
 
@@ -168,6 +169,7 @@ You can refer to my configuration:
 "markdownFormatter.formatOpt": {
   "indent_size": 2
 },
+"markdownFormatter.endOfLineSpaces": 2,
 "[markdown]": {
   // auto save
   "editor.formatOnSave": false,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ var formatCodes: boolean = config.get<boolean>('formatCodes', true)
 let formatOpt: any = config.get<any>('formatOpt', {});
 let formatULSymbol: boolean = config.get<boolean>('formatULSymbol', true);
 let spaceAfterFullWidth: boolean = config.get<boolean>('spaceAfterFullWidth', false);
+let endOfLineSpaces: number = config.get<number>('endOfLineSpaces', 2);
 
 vscode.workspace.onDidChangeConfiguration(_ => {
     config = vscode.workspace.getConfiguration('markdownFormatter');
@@ -31,6 +32,7 @@ vscode.workspace.onDidChangeConfiguration(_ => {
     formatOpt = config.get<any>('formatOpt', {});
     formatULSymbol = config.get<boolean>('formatULSymbol', true);
     spaceAfterFullWidth = config.get<boolean>('spaceAfterFullWidth', false);
+    endOfLineSpaces = config.get<number>('endOfLineSpaces', 2);
 });
 
 // console.log(vscode.window.activeTextEditor.options.tabSize)
@@ -163,6 +165,7 @@ export function formatted(textP: string): string {
         text = text.replace(LINE_THROUGH_EXP, '~~$1~~')
         // clear breakline
         text = text.replace(BEGIN_LINE_EXP, '')
+        text = text.replace(/(\.|\?|\!)+\s+\n/g, '$1' + ' '.repeat(endOfLineSpaces) +  '\n\n')
 
         // decrease end line
         // https://github.com/sumnow/markdown-formatter/issues/24


### PR DESCRIPTION
Found that the formatted code did not comply with MD009 because it allowed to many spaces at the end of a line. Added a simple regex to replace that. Since MD009 allows the `br_spaces` parameter to determine exceptions I've also added it as a configurable option, it defaults to 2.  